### PR TITLE
feat(platforms): get by id

### DIFF
--- a/server/API/Controllers/Platform.cs
+++ b/server/API/Controllers/Platform.cs
@@ -50,4 +50,40 @@ public class Platform : ControllerBase
         }
         );
     }
+
+    [Authorize(policy: "UserOrAdmin")]
+    [HttpGet]
+    public async Task<IActionResult> GetAllPlatforms()
+    {
+        var response = await _platformRepo.GetAllPlatformsAsync();
+        return Ok(new
+        {
+            status = "success",
+            message = response.Message,
+            data = response.Platforms
+        }
+        );
+    }
+
+    [Authorize(policy: "UserOrAdmin")]
+    [HttpGet("{id}")]
+    public async Task<IActionResult> GetAPlatforms(string id)
+    {
+        var response = await _platformRepo.GetAPlatformAsync(id);
+        if (!response.Flag)
+        {
+            return BadRequest(new
+            {
+                status = "fail",
+                message = response.Message
+            });
+        }
+        return Ok(new
+        {
+            status = "success",
+            message = response.Message,
+            data = response.Platform
+        }
+        );
+    }
 }

--- a/server/Application/Contracts/IPlatform.cs
+++ b/server/Application/Contracts/IPlatform.cs
@@ -8,4 +8,5 @@ public interface IPlatform
     Task<CreatePlatformResponse> CreatePlatformAsync(CreatePlatformRequestDto dto);
     Task<UpdatePlatformResponse> UpdatePlatformAsync(string id, UpdatePlatformRequestDto dto);
     Task<GetAllPlatformsResponse> GetAllPlatformsAsync(bool? isSupported = null);
+    Task<GetAPlatformResponseDto> GetAPlatformAsyn(string id);
 }

--- a/server/Application/Contracts/IPlatform.cs
+++ b/server/Application/Contracts/IPlatform.cs
@@ -8,5 +8,5 @@ public interface IPlatform
     Task<CreatePlatformResponse> CreatePlatformAsync(CreatePlatformRequestDto dto);
     Task<UpdatePlatformResponse> UpdatePlatformAsync(string id, UpdatePlatformRequestDto dto);
     Task<GetAllPlatformsResponse> GetAllPlatformsAsync(bool? isSupported = null);
-    Task<GetAPlatformResponseDto> GetAPlatformAsyn(string id);
+    Task<GetAPlatformResponseDto> GetAPlatformAsync(string id);
 }

--- a/server/Application/Dtos/Platform/GetAPlatformRequestDto.cs
+++ b/server/Application/Dtos/Platform/GetAPlatformRequestDto.cs
@@ -1,8 +1,0 @@
-using System.ComponentModel.DataAnnotations;
-namespace Application.Dtos.Platform;
-
-public class GetAPlatformRequestDto
-{
-    [Required(ErrorMessage = "A platform id is requried")]
-    public required Guid Id { get; set; }
-}

--- a/server/Application/Dtos/Platform/GetAPlatformRequestDto.cs
+++ b/server/Application/Dtos/Platform/GetAPlatformRequestDto.cs
@@ -1,0 +1,8 @@
+using System.ComponentModel.DataAnnotations;
+namespace Application.Dtos.Platform;
+
+public class GetAPlatformRequestDto
+{
+    [Required(ErrorMessage = "A platform id is requried")]
+    public required Guid Id { get; set; }
+}

--- a/server/Application/Dtos/Platform/GetAPlatformResponseDto.cs
+++ b/server/Application/Dtos/Platform/GetAPlatformResponseDto.cs
@@ -1,2 +1,2 @@
 namespace Application.Dtos.Platform;
-public record GetAPlatformResponseDto(bool Flag, string Message, Core.Entities.Platform Platform);
+public record GetAPlatformResponseDto(bool Flag, string Message, Core.Entities.Platform? Platform);

--- a/server/Application/Dtos/Platform/GetAPlatformResponseDto.cs
+++ b/server/Application/Dtos/Platform/GetAPlatformResponseDto.cs
@@ -1,0 +1,2 @@
+namespace Application.Dtos.Platform;
+public record GetAPlatformResponseDto(bool Flag, string Message, Core.Entities.Platform Platform);

--- a/server/Application/Dtos/Platform/GetAllPlatformsResponseDto.cs
+++ b/server/Application/Dtos/Platform/GetAllPlatformsResponseDto.cs
@@ -1,4 +1,2 @@
-using Core.Entities;
-
 namespace Application.Dtos.Platform;
 public record GetAllPlatformsResponse(bool Flag, string Message, List<Core.Entities.Platform> Platforms);

--- a/server/Infrastructure/Repos/PlatformRepo.cs
+++ b/server/Infrastructure/Repos/PlatformRepo.cs
@@ -76,6 +76,13 @@ public class PlatformRepo : IPlatform
         return new UpdatePlatformResponse(true, "Platform updated successfully");
     }
 
+    public async Task<GetAPlatformResponseDto> GetAPlatformAsync(string id)
+    {
+        var platform = await PlatformByIdExists(id);
+        if (platform == null) return new GetAPlatformResponseDto(false, "No platform found", null);
+        return new GetAPlatformResponseDto(true, "Platform successfully fetched", platform);
+    }
+
     private async Task<Platform?> PlatformByIdExists(string id)
     {
         return await _appDbContext.Platforms.FirstOrDefaultAsync(x => x.Id.ToString() == id);


### PR DESCRIPTION
- [x] Added get a platform by id endpoint 
- [x] Added get-all platforms  controller (the rest of the logic of this endpoint was already implemented)
- [x] Tested locally on swagger
- [x] Screenshot/s
![Screenshot 2024-08-19 at 4 25 34 PM](https://github.com/user-attachments/assets/6f26bd5d-ce5a-4bc1-b29a-8cccf00a6597)
![Screenshot 2024-08-19 at 4 25 51 PM](https://github.com/user-attachments/assets/2cfe0ffb-5e08-439d-a1e1-c3ced914ea3b)
